### PR TITLE
Remove support for bindings on Group to simplify tree structure.

### DIFF
--- a/Sources/Scribe/DSL/Block.swift
+++ b/Sources/Scribe/DSL/Block.swift
@@ -20,7 +20,8 @@ extension Never: Block {
 
 extension Block {
   func optimizeTree() -> L2Element {
-    self.toL1Element().toL2Element()
+    self.toL1Element()
+      .toL2Element()
   }
 }
 

--- a/Sources/Scribe/DSL/Blocks/Modified.swift
+++ b/Sources/Scribe/DSL/Blocks/Modified.swift
@@ -1,7 +1,7 @@
 /// Modified
 public typealias BlockAction = () -> Void
 
-extension Block {
+extension String {
   /// Bind a key to this ``Block`` allowing interaction and emulate the
   /// conventional button.
   /// - Parameters:
@@ -10,6 +10,7 @@ extension Block {
   /// the key is pressed
   /// - Returns: A wrapper around the block containing the information needed
   /// to execute the code.
+  @MainActor
   public func bind(key: String, action: @escaping BlockAction) -> some Block {
     // TODO update key to be a type to handle ctrl and shift combinations.
     Modified(wrapped: self, key: key, action: action)

--- a/Sources/Scribe/Tree/ActionWalker.swift
+++ b/Sources/Scribe/Tree/ActionWalker.swift
@@ -9,12 +9,9 @@ struct ActionWalker: L2HashWalker {
     self.input = input
   }
 
-  mutating func beforeGroup(_ group: [L2Element], _ binding: L2Binding?) {
-    Log.debug("\(#function): \(currentHash), \(state.selected)")
-    runBinding(binding)
-  }
+  mutating func beforeGroup(_ group: [L2Element]) {}
 
-  mutating func afterGroup(_ group: [L2Element], _ binding: L2Binding?) {}
+  mutating func afterGroup(_ group: [L2Element]) {}
 
   mutating func walkText(_ text: String, _ binding: L2Binding?) {
     Log.debug("\(#function): \(currentHash), \(state.selected)")

--- a/Sources/Scribe/Tree/InitialWalk.swift
+++ b/Sources/Scribe/Tree/InitialWalk.swift
@@ -9,11 +9,11 @@ struct InitialWalk: L2HashWalker {
     self.currentHash = hash(contents: "0")
   }
 
-  mutating func beforeGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func beforeGroup(_ group: [L2Element]) {
     setFirstSelection()
   }
 
-  mutating func afterGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func afterGroup(_ group: [L2Element]) {
     // ignored
   }
 

--- a/Sources/Scribe/Tree/L1Element.swift
+++ b/Sources/Scribe/Tree/L1Element.swift
@@ -10,11 +10,16 @@ extension L1Element {
   func toL2Element() -> L2Element {
     switch self {
     case let .group(group):
-      return .group(group.map { $0.toL2Element() }, nil)
+      return .group(group.map { $0.toL2Element() })
     case let .text(text):
       return .text(text, nil)
     case let .wrapped(element, key, action):
-      return .group([element.toL2Element()], L2Binding(key: key, action: action))
+      switch element.toL2Element() {
+      case let .text(text, .none):
+        return .text(text, L2Binding(key: key, action: action))
+      default:
+        precondition(false, "Bindings on Groups not aloud right now")
+      }
     }
   }
 }

--- a/Sources/Scribe/Tree/L2Element.swift
+++ b/Sources/Scribe/Tree/L2Element.swift
@@ -1,6 +1,6 @@
 enum L2Element {
   case text(String, L2Binding?)
-  case group([L2Element], L2Binding?)
+  case group([L2Element])
 }
 
 struct L2Binding {

--- a/Sources/Scribe/Tree/TreeMovement/MoveDownWalker.swift
+++ b/Sources/Scribe/Tree/TreeMovement/MoveDownWalker.swift
@@ -31,13 +31,13 @@ struct MoveDownWalker: L2ElementWalker {
     path.removeLast()
   }
 
-  mutating func beforeGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func beforeGroup(_ group: [L2Element]) {
     appendPath(siblings: group.count - 1)
   }
 
-  mutating func walkGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func walkGroup(_ group: [L2Element]) {
     let ourHash = currentHash
-    beforeGroup(group, binding)
+    beforeGroup(group)
     child_loop: for (index, element) in group.enumerated() {
       switch mode {
       case .foundSelected:
@@ -75,10 +75,10 @@ struct MoveDownWalker: L2ElementWalker {
       }
     }
     currentHash = ourHash
-    afterGroup(group, binding)
+    afterGroup(group)
   }
 
-  mutating func afterGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func afterGroup(_ group: [L2Element]) {
     path.removeLast()
   }
 

--- a/Sources/Scribe/Tree/TreeMovement/MoveInWalker.swift
+++ b/Sources/Scribe/Tree/TreeMovement/MoveInWalker.swift
@@ -41,13 +41,13 @@ struct MoveInWalker: L2ElementWalker {
     path.removeLast()
   }
 
-  mutating func beforeGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func beforeGroup(_ group: [L2Element]) {
     appendPath(siblings: group.count - 1)
   }
 
-  mutating func walkGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func walkGroup(_ group: [L2Element]) {
     let ourHash = currentHash
-    beforeGroup(group, binding)
+    beforeGroup(group)
     switch mode {
     case .findingSelected:
       ()
@@ -73,10 +73,10 @@ struct MoveInWalker: L2ElementWalker {
       }
     }
     currentHash = ourHash
-    afterGroup(group, binding)
+    afterGroup(group)
   }
 
-  mutating func afterGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func afterGroup(_ group: [L2Element]) {
     path.removeLast()
   }
 

--- a/Sources/Scribe/Tree/TreeMovement/MoveOutWalker.swift
+++ b/Sources/Scribe/Tree/TreeMovement/MoveOutWalker.swift
@@ -25,13 +25,13 @@ struct MoveOutWalker: L2ElementWalker {
     path.removeLast()
   }
 
-  mutating func beforeGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func beforeGroup(_ group: [L2Element]) {
     appendPath(siblings: group.count - 1)
   }
 
-  mutating func walkGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func walkGroup(_ group: [L2Element]) {
     let ourHash = currentHash
-    beforeGroup(group, binding)
+    beforeGroup(group)
     for (index, element) in group.enumerated() {
       currentHash = hash(contents: "\(ourHash)\(#function)\(index)")
       walk(element)
@@ -49,10 +49,10 @@ struct MoveOutWalker: L2ElementWalker {
       ()
     }
     currentHash = ourHash
-    afterGroup(group, binding)
+    afterGroup(group)
   }
 
-  mutating func afterGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func afterGroup(_ group: [L2Element]) {
     path.removeLast()
   }
 

--- a/Sources/Scribe/Tree/TreeMovement/MoveUpWalker.swift
+++ b/Sources/Scribe/Tree/TreeMovement/MoveUpWalker.swift
@@ -26,13 +26,13 @@ struct MoveUpWalker: L2ElementWalker {
     appendPath(siblings: 0)
     path.removeLast()
   }
-  mutating func beforeGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func beforeGroup(_ group: [L2Element]) {
     appendPath(siblings: group.count - 1)
   }
 
-  mutating func walkGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func walkGroup(_ group: [L2Element]) {
     let ourHash = currentHash
-    beforeGroup(group, binding)
+    beforeGroup(group)
 
     child_loop: for (index, element) in group.enumerated().reversed() {
       switch mode {
@@ -72,10 +72,10 @@ struct MoveUpWalker: L2ElementWalker {
     }
 
     currentHash = ourHash
-    afterGroup(group, binding)
+    afterGroup(group)
   }
 
-  mutating func afterGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func afterGroup(_ group: [L2Element]) {
     path.removeLast()
   }
 

--- a/Sources/Scribe/Tree/TreeWalker/L2ElementWalker.swift
+++ b/Sources/Scribe/Tree/TreeWalker/L2ElementWalker.swift
@@ -1,7 +1,7 @@
 @MainActor
 protocol L2ElementWalker {
   mutating func walkText(_ text: String, _ binding: L2Binding?)
-  mutating func walkGroup(_ group: [L2Element], _ binding: L2Binding?)
+  mutating func walkGroup(_ group: [L2Element])
 }
 
 /*

--- a/Sources/Scribe/Tree/TreeWalker/L2HashWalker.swift
+++ b/Sources/Scribe/Tree/TreeWalker/L2HashWalker.swift
@@ -5,21 +5,21 @@ import Crypto
 /// independent of the contains of the block IE it's mutations.
 protocol L2HashWalker: L2ElementWalker {
   var currentHash: Hash { get set }
-  mutating func beforeGroup(_ group: [L2Element], _ binding: L2Binding?)
-  mutating func afterGroup(_ group: [L2Element], _ binding: L2Binding?)
+  mutating func beforeGroup(_ group: [L2Element])
+  mutating func afterGroup(_ group: [L2Element])
 }
 
 extension L2HashWalker {
 
-  mutating func walkGroup(_ group: [L2Element], _ binding: L2Binding?) {
-    beforeGroup(group, binding)
+  mutating func walkGroup(_ group: [L2Element]) {
+    beforeGroup(group)
     let ourHash = currentHash
     for (index, element) in group.enumerated() {
       currentHash = hash(contents: "\(ourHash)\(#function)\(index)")
       walk(element)
     }
     currentHash = ourHash
-    afterGroup(group, binding)
+    afterGroup(group)
   }
 }
 

--- a/Sources/Scribe/Tree/TreeWalker/L2SelectionWalker.swift
+++ b/Sources/Scribe/Tree/TreeWalker/L2SelectionWalker.swift
@@ -17,11 +17,11 @@ extension L2SelectionWalker {
       isSelected = false
     }
   }
-  mutating func beforeGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func beforeGroup(_ group: [L2Element]) {
     updateSelected()
   }
 
-  mutating func afterGroup(_ group: [L2Element], _ binding: L2Binding?) {
+  mutating func afterGroup(_ group: [L2Element]) {
     resetSelected()
   }
 

--- a/Sources/Scribe/Tree/TreeWalker/Walkable.swift
+++ b/Sources/Scribe/Tree/TreeWalker/Walkable.swift
@@ -8,8 +8,8 @@ protocol L2Walkable {
 extension L2Element: L2Walkable {
   func _walk(_ walker: inout some L2ElementWalker) {
     switch self {
-    case let .group(group, binding):
-      walker.walkGroup(group, binding)
+    case let .group(group):
+      walker.walkGroup(group)
     case let .text(text, binding):
       walker.walkText(text, binding)
     }


### PR DESCRIPTION
This PR Simplifies the tree structure  by removing support for adding bindings to Groups. This feature may be useful in the future but for right now it simplifies flattening out the tree for more ergonomic movements.