### PR TITLE
Flatten group layers

### DIFF
--- a/Sources/Scribe/DSL/Block.swift
+++ b/Sources/Scribe/DSL/Block.swift
@@ -22,6 +22,7 @@ extension Block {
   func optimizeTree() -> L2Element {
     self.toL1Element()
       .toL2Element()
+      .flatten()
   }
 }
 

--- a/Sources/Scribe/Tree/L2Element.swift
+++ b/Sources/Scribe/Tree/L2Element.swift
@@ -7,3 +7,26 @@ struct L2Binding {
   let key: String
   let action: BlockAction
 }
+
+extension L2Element {
+  /// Flattens groups of like orientation into one layer to make navigation
+  /// easier.
+  /// - Returns:
+  func flatten() -> L2Element {
+    switch self {
+    case let .group(group):
+      var children: [L2Element] = []
+      for child in group.map { $0.flatten() } {
+        switch child {
+        case let .group(grandChildren):
+          children += grandChildren.map { $0.flatten() }
+        case .text:
+          children.append(child)
+        }
+      }
+      return .group(children)
+    case .text:
+      return self
+    }
+  }
+}

--- a/Tests/ScribeTests/SelectionTests.swift
+++ b/Tests/ScribeTests/SelectionTests.swift
@@ -23,14 +23,6 @@ struct SelectionTests {
     container.expectState(
       &renderer,
       expected: [
-        "[Nested[text: Hello]]", "[Zane was here :0]", "[Hello, I am Scribe.]",
-        "[Job running: ready]",
-      ])
-
-    container.moveIn()
-    container.expectState(
-      &renderer,
-      expected: [
         "[Hello, I am Scribe.]", "Job running: ready", "Nested[text: Hello]", "Zane was here :0",
       ])
 
@@ -168,7 +160,7 @@ struct SelectionTests {
     var renderer = TestRenderer()
     container.expectState(&renderer, expected: ["[Hello]", "[Zane]"])
     container.moveIn()
-    container.expectState(&renderer, expected: ["[Hello]", "[Zane]"])
+    container.expectState(&renderer, expected: ["[Hello]", "Zane"])
     container.moveIn()
     container.expectState(&renderer, expected: ["[Hello]", "Zane"])
   }
@@ -238,10 +230,6 @@ struct SelectionTests {
       &renderer, expected: ["[0]", "[1]", "[2]", "[Hello]", "[Zane]", "[here]", "[was]"])
 
     container.moveIn()
-    container.expectState(
-      &renderer, expected: ["[0]", "[1]", "[2]", "[Hello]", "[Zane]", "[here]", "[was]"])
-
-    container.moveIn()
     container.expectState(&renderer, expected: ["0", "1", "2", "Zane", "[Hello]", "here", "was"])
 
     container.moveIn()
@@ -266,10 +254,6 @@ struct SelectionTests {
     container.expectState(&renderer, expected: ["0", "1", "2", "Zane", "Hello", "[here]", "was"])
 
     container.moveDown()
-    container.expectState(
-      &renderer, expected: ["[0]", "[1]", "[2]", "Zane", "Hello", "here", "was"])
-
-    container.moveIn()
     container.expectState(&renderer, expected: ["[0]", "1", "2", "Zane", "Hello", "here", "was"])
 
     container.moveDown()
@@ -286,10 +270,6 @@ struct SelectionTests {
 
     container.moveUp()
     container.expectState(&renderer, expected: ["0", "[1]", "2", "Zane", "Hello", "here", "was"])
-
-    container.moveOut()
-    container.expectState(
-      &renderer, expected: ["[0]", "[1]", "[2]", "Zane", "Hello", "here", "was"])
 
     container.moveOut()
     container.expectState(


### PR DESCRIPTION
This PR induces a flatten phase to parsing and rendering the Block tree. This flattens groups down to reduce the amount of "vertical"(up and down) movements you need to make to traverse a tree.